### PR TITLE
Fixed prototype pollution on objer

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,10 @@
 export function set(object, path, value) {
   let subObject = object;
   const keys = getObjectPath(path);
+ 
+  if(path.includes('__proto__') || path.includes('constructor') || path.includes('prototype')){
+    return object;
+  }
   if (keys.length === 0) return value; // We cannot modify the original value to be the new value no matter how hard we try
   for (let keydex = 0; keydex < keys.length; keydex += 1) {
     let key = keys[keydex];


### PR DESCRIPTION
### 📊 Metadata *

Prototype Pollution bug

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-objer

### ⚙️ Description *

`objer` is vulnerable to Prototype Pollution. This package allowing for modification of prototype behavior, which may result in Information Disclosure/DoS/RCE.

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.

### 💻 Technical Description *

The bug is fixed by validating the input `path` to check for prototypes. It is implemented by a simple validation to check for prototype keywords `(__proto__, constructor and prototype)`, where if it exists, the function returns the object without modifying it, thus fixing the Prototype Pollution Vulnerability. 

### 🐛 Proof of Concept (PoC) *

Clone the project, install the required dependencies and on running the below snippet of code, it triggers prototype pollution and logs `Yes! Its Polluted`.
```javascript
// poc.js
var objer = require("objer")
var obj = {}
console.log("Before : " + {}.polluted);
objer.set(obj,["__proto__","polluted"],"Yes! Its Polluted");
console.log("After : " + {}.polluted);
```

![image](https://user-images.githubusercontent.com/16708391/107805256-18452b00-6d8b-11eb-8311-a794f5eb43e6.png)


### 🔥 Proof of Fix (PoF) *

After the fix is applied, it returns `undefined` since the polluted referred in the PoC is no more accessible(which is intended). Hence fixing the issue.


### 👍 User Acceptance Testing (UAT)

Just prevented some keywords as `path` and no breaking changes are introduced. :)
